### PR TITLE
Remove deprecated bottle unneeded

### DIFF
--- a/Formula/reviewdog.rb
+++ b/Formula/reviewdog.rb
@@ -6,7 +6,6 @@ class Reviewdog < Formula
   desc "Automated code review tool integrated with any code analysis tools regardless of programming language."
   homepage "https://github.com/reviewdog/reviewdog"
   version "0.13.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
This is fixed in the latest GoReleaser. So whenever Reviewdog publishes a new version it will stay this way.
By fixing this manually we remove the deprecation for every user of this tap.

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the reviewdog/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/reviewdog/homebrew-tap/Formula/reviewdog.rb:9
```